### PR TITLE
Add required packages in the setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 .idea
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ setup(name='greentornado',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
+    install_requires=[
+        'eventlet',
+        'tornado',
+    ],
     classifiers=CLASSIFIERS,
     test_suite='tests',
 )


### PR DESCRIPTION
If the [`install_requires` option](http://pythonhosted.org/distribute/setuptools.html#new-and-changed-setup-keywords) is presented on the `setup.py`, required packages will be automatically installed when running `python setup.py install`, or `pip install greentornado` after you've uploaded this package in the PyPI. This is also useful in development. Try `python setup.py develop`.
