### PR TITLE
Wraps greened function to imitate the original function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .idea
 *.egg-info/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "pypy"
+install:
+  - pip install .
+  - pip install pytest
+script: py.test

--- a/greentornado.py
+++ b/greentornado.py
@@ -5,6 +5,7 @@ import eventlet
 import time
 import sys
 import inspect
+import functools
 
 def greenify(cls_or_func):
     """Decorate classes or functions with this to make them spawn as 
@@ -15,9 +16,10 @@ def greenify(cls_or_func):
         cls_or_func._execute = lambda self, *args, **kwargs: eventlet.spawn_n(execute, self, *args, **kwargs)
         return cls_or_func
     else:
+        @functools.wraps(cls_or_func)
         def wrapper(*args, **kwargs):
-            eventlet.spawn_n(cls_or_func, *args, **kwargs)
-        setattr(wrapper, 'original', cls_or_func)
+            return eventlet.spawn_n(cls_or_func, *args, **kwargs)
+        wrapper.original = cls_or_func
         return wrapper
 
 class Timer(timer.Timer):

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(name='greentornado',
         'eventlet',
         'tornado',
     ],
+    tests_require=['pytest'],
     classifiers=CLASSIFIERS,
     test_suite='tests',
 )

--- a/test_greentornado.py
+++ b/test_greentornado.py
@@ -1,0 +1,39 @@
+import pytest
+import greentornado
+
+
+def test_greenify_a_functions():
+    """@greenify should succefully imitates the decorated function."""
+    @greentornado.greenify
+    def job():
+        """Do something with eventlet"""
+        pass
+    assert job.__name__ == 'job'
+    assert job.__module__ == __name__
+    assert job.__doc__ == 'Do something with eventlet'
+    assert job.original != job
+
+    def work():
+        """Work with eventlet"""
+        pass
+    work_g = greentornado.greenify(work)
+    assert work_g.original == work
+    assert work_g.__name__ == work.__name__
+    assert work_g.__module__ == work.__module__
+    assert work_g.__doc__ == work.__doc__
+
+
+def test_call_later():
+    class MockTimer(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+    with pytest.raises(AssertionError):
+        greentornado.call_later(MockTimer, 12, 'function')
+    with pytest.raises(TypeError):
+        greentornado.call_later(MockTimer, '0.2 seconds', lambda: None)
+    with pytest.raises(AssertionError):
+        greentornado.call_later(MockTimer, -1, lambda: None)
+
+    t = greentornado.call_later(MockTimer, 3, lambda: None)
+    assert isinstance(t, MockTimer)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26,py27,pypy
+[testenv]
+deps = pytest
+changedir = {toxinidir}
+commands = py.test


### PR DESCRIPTION
There was a problem that the function decorated by `@greenify` doesn't look like the original one. for example:

``` py
@greentornado.greenify
def job():
    """Do something"""
    pass

assert job.__doc__ == 'Do something'  # fail
```

It can be messed in some cases like inspecting that function, or doing [doctest](http://docs.python.org/2/library/doctest.html), or documenting using [Sphinx](http://sphinx-doc.org/), or else. So I decorated the wrapper function with [`@functools.wraps`](http://docs.python.org/2/library/functools.html#functools.wraps)

To convince myself (and the other contributors in the future) that this change works properly, I added some simple tests about that changes. [py.test](http://pytest.org/latest/) and [tox](http://tox.readthedocs.org/en/latest/) are also introduced for the convenient testing.
